### PR TITLE
Update app.toml gRPC port

### DIFF
--- a/10001/app.toml
+++ b/10001/app.toml
@@ -135,7 +135,7 @@ enabled-unsafe-cors = false
 enable = true
 
 # Address defines the gRPC server address to bind to.
-address = "0.0.0.0:9900"
+address = "0.0.0.0:9090"
 
 ###############################################################################
 ###                           EVM RPC Configuration                         ###


### PR DESCRIPTION
The docs here use the Cosmos default of 9090: https://docs.injective.network/nodes/validators/mainnet/peggo

We had issues with using 9900 but 9090 worked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the gRPC server port configuration from 9900 to 9090.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->